### PR TITLE
记录服务自动安装失败原因

### DIFF
--- a/App/Services/ServiceManagement/ServiceInstallManager.cs
+++ b/App/Services/ServiceManagement/ServiceInstallManager.cs
@@ -6,6 +6,8 @@ namespace SwiftList.App.Services;
 
 public static class ServiceInstallManager
 {
+    private const int InstallerTimeoutMs = 30000;
+    private const int StartTimeoutMs = 10000;
     private static int _silentInstallInFlight;
 
     public static string GetServiceExePath()
@@ -24,18 +26,10 @@ public static class ServiceInstallManager
         {
             var serviceExePath = GetServiceExePath();
             Logger.Log($"[ServiceInstallManager] Requesting service installation: {serviceExePath} --install");
-            var psi = new ProcessStartInfo
-            {
-                FileName = serviceExePath,
-                Arguments = "--install",
-                Verb = "runas",
-                UseShellExecute = true,
-                WindowStyle = ProcessWindowStyle.Hidden
-            };
-
-            var proc = Process.Start(psi);
-            proc?.WaitForExit();
-            onCompleted?.Invoke();
+            if (RunElevatedInstaller("Service installation", serviceExePath))
+                onCompleted?.Invoke();
+            else
+                onError?.Invoke(new InvalidOperationException("Service installation did not complete successfully."));
         }
         catch (Exception ex)
         {
@@ -56,17 +50,19 @@ public static class ServiceInstallManager
         {
             var serviceExePath = GetServiceExePath();
             Logger.Log($"[ServiceInstallManager] Attempting silent service installation: {serviceExePath}");
-            var psi = new ProcessStartInfo
-            {
-                FileName = serviceExePath,
-                Arguments = "--install",
-                Verb = "runas",
-                UseShellExecute = true,
-                WindowStyle = ProcessWindowStyle.Hidden
-            };
+            if (!RunElevatedInstaller("Silent service installation", serviceExePath))
+                return true;
 
-            var proc = Process.Start(psi);
-            proc?.WaitForExit();
+            if (!IsInstalledAtCurrentPath())
+            {
+                Logger.Log("[ServiceInstallManager] Silent install finished but SwiftListService is not registered at the current service path.", LogLevel.Error);
+                return true;
+            }
+
+            if (TryStartWithoutElevation())
+                Logger.Log("[ServiceInstallManager] SwiftListService is registered at the current path and start command succeeded.");
+            else
+                Logger.Log("[ServiceInstallManager] SwiftListService is registered at the current path but start command failed.", LogLevel.Warn);
         }
         catch (Exception ex)
         {
@@ -79,6 +75,35 @@ public static class ServiceInstallManager
         }
 
         return true;
+    }
+
+    private static bool RunElevatedInstaller(string operation, string serviceExePath)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = serviceExePath,
+            Arguments = "--install",
+            Verb = "runas",
+            UseShellExecute = true,
+            WindowStyle = ProcessWindowStyle.Hidden
+        };
+
+        using var proc = Process.Start(psi);
+        if (proc == null)
+        {
+            Logger.Log($"[ServiceInstallManager] {operation} failed: Process.Start returned null.", LogLevel.Error);
+            return false;
+        }
+
+        if (!proc.WaitForExit(InstallerTimeoutMs))
+        {
+            Logger.Log($"[ServiceInstallManager] {operation} timed out after {InstallerTimeoutMs}ms.", LogLevel.Error);
+            TryKill(proc);
+            return false;
+        }
+
+        Logger.Log($"[ServiceInstallManager] {operation} exited with code {proc.ExitCode}.");
+        return proc.ExitCode == 0;
     }
 
     /// <summary>
@@ -142,9 +167,16 @@ public static class ServiceInstallManager
             using var proc = Process.Start(psi);
             if (proc == null)
                 return false;
-            proc.WaitForExit(10000);
+            if (!proc.WaitForExit(StartTimeoutMs))
+            {
+                Logger.Log($"[ServiceInstallManager] Non-elevated start timed out after {StartTimeoutMs}ms.", LogLevel.Warn);
+                TryKill(proc);
+                return false;
+            }
             // 0 = started; 1056 = ERROR_SERVICE_ALREADY_RUNNING.
-            return proc.ExitCode == 0 || proc.ExitCode == 1056;
+            var success = proc.ExitCode == 0 || proc.ExitCode == 1056;
+            Logger.Log($"[ServiceInstallManager] Non-elevated start exited with code {proc.ExitCode}.", success ? LogLevel.Info : LogLevel.Warn);
+            return success;
         }
         catch (Exception ex)
         {
@@ -159,4 +191,15 @@ public static class ServiceInstallManager
     /// </summary>
     public static bool TryStartExistingService()
         => IsInstalledAtCurrentPath() && TryStartWithoutElevation();
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch
+        {
+        }
+    }
 }

--- a/Service/Program.cs
+++ b/Service/Program.cs
@@ -90,64 +90,34 @@ static class Program
 
             // Clean up any existing service instance to prevent "1073: service already exists" errors
             Logger.Log("Cleaning up existing service instance before install.");
-            var psiStop = new ProcessStartInfo
-            {
-                FileName = "sc.exe",
-                Arguments = "stop SwiftListService",
-                UseShellExecute = true,
-                WindowStyle = ProcessWindowStyle.Hidden
-            };
-            Process.Start(psiStop)?.WaitForExit();
-
-            var psiDelete = new ProcessStartInfo
-            {
-                FileName = "sc.exe",
-                Arguments = "delete SwiftListService",
-                UseShellExecute = true,
-                WindowStyle = ProcessWindowStyle.Hidden
-            };
-            Process.Start(psiDelete)?.WaitForExit();
+            ServiceControlRunner.Run("stop SwiftListService", 0, 1060, 1062);
+            ServiceControlRunner.Run("delete SwiftListService", 0, 1060);
 
             Logger.Log($"Installing service: sc.exe create SwiftListService binPath=\"{serviceExePath} --service\"");
 
-            var psiCreate = new ProcessStartInfo
-            {
-                FileName = "sc.exe",
-                Arguments = $"create SwiftListService binPath= \"\\\"{serviceExePath}\\\" --service\" start= auto DisplayName= \"SwiftList Background Service\"",
-                UseShellExecute = true,
-                WindowStyle = ProcessWindowStyle.Hidden
-            };
-            var proc = Process.Start(psiCreate);
-            proc?.WaitForExit();
+            var create = ServiceControlRunner.Run($"create SwiftListService binPath= \"\\\"{serviceExePath}\\\" --service\" start= auto DisplayName= \"SwiftList Background Service\"");
+            if (!create.IsSuccess(0))
+                throw new InvalidOperationException("sc create failed. See service.log for details.");
 
             // Grant all authenticated users START/STOP/QUERY on the service so the non-elevated app can
             // start and stop it without a UAC prompt every time. Install is already elevated here, so this
             // one-time descriptor change is free. SYSTEM and Administrators keep full control.
             // AU ACE = CC LC SW RP WP LO RC = query-config/status, enum-deps, start, stop, interrogate, read.
             Logger.Log("Setting service security descriptor to allow non-admin start/stop.");
-            var psiSdset = new ProcessStartInfo
-            {
-                FileName = "sc.exe",
-                Arguments = "sdset SwiftListService D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;CCLCSWRPWPLORC;;;AU)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)",
-                UseShellExecute = true,
-                WindowStyle = ProcessWindowStyle.Hidden
-            };
-            Process.Start(psiSdset)?.WaitForExit();
+            var sdset = ServiceControlRunner.Run("sdset SwiftListService D:(A;;CCLCSWRPWPDTLOCRRC;;;SY)(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;BA)(A;;CCLCSWLOCRRC;;;IU)(A;;CCLCSWLOCRRC;;;SU)(A;;CCLCSWRPWPLORC;;;AU)S:(AU;FA;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;WD)");
+            if (!sdset.IsSuccess(0))
+                Logger.Log("[ServiceInstaller] Service was created but sdset failed; non-admin start/stop may require elevation.", LogLevel.Warn);
 
             Logger.Log("Starting service: sc.exe start SwiftListService");
-            var psiStart = new ProcessStartInfo
-            {
-                FileName = "sc.exe",
-                Arguments = "start SwiftListService",
-                UseShellExecute = true,
-                WindowStyle = ProcessWindowStyle.Hidden
-            };
-            Process.Start(psiStart)?.WaitForExit();
+            var start = ServiceControlRunner.Run("start SwiftListService", 0, 1056);
+            if (!start.IsSuccess(0, 1056))
+                throw new InvalidOperationException("sc start failed. See service.log for details.");
 
             Console.WriteLine("Service installed and started successfully!");
         }
         catch (Exception ex)
         {
+            Environment.ExitCode = 1;
             Console.WriteLine($"Failed to install service: {ex.Message}");
             Logger.Log($"Failed to install service: {ex}", LogLevel.Error);
         }
@@ -158,27 +128,18 @@ static class Program
         try
         {
             Logger.Log("Stopping service: sc.exe stop SwiftListService");
-            var psiStop = new ProcessStartInfo
-            {
-                FileName = "sc.exe",
-                Arguments = "stop SwiftListService",
-                UseShellExecute = true
-            };
-            Process.Start(psiStop)?.WaitForExit();
+            ServiceControlRunner.Run("stop SwiftListService", 0, 1060, 1062);
 
             Logger.Log("Deleting service: sc.exe delete SwiftListService");
-            var psiDelete = new ProcessStartInfo
-            {
-                FileName = "sc.exe",
-                Arguments = "delete SwiftListService",
-                UseShellExecute = true
-            };
-            Process.Start(psiDelete)?.WaitForExit();
+            var delete = ServiceControlRunner.Run("delete SwiftListService", 0, 1060);
+            if (!delete.IsSuccess(0, 1060))
+                throw new InvalidOperationException("sc delete failed. See service.log for details.");
 
             Console.WriteLine("Service uninstalled successfully!");
         }
         catch (Exception ex)
         {
+            Environment.ExitCode = 1;
             Console.WriteLine($"Failed to uninstall service: {ex.Message}");
             Logger.Log($"Failed to uninstall service: {ex}", LogLevel.Error);
         }

--- a/Service/ServiceControlRunner.cs
+++ b/Service/ServiceControlRunner.cs
@@ -1,0 +1,81 @@
+using System.Diagnostics;
+using SwiftList.Core;
+
+namespace SwiftList.Service;
+
+internal static class ServiceControlRunner
+{
+    private const int TimeoutMs = 30000;
+
+    public static ServiceCommandResult Run(string arguments, params int[] successExitCodes)
+    {
+        successExitCodes = successExitCodes.Length == 0 ? [0] : successExitCodes;
+        Logger.Log($"[ServiceInstaller] Running: sc.exe {arguments}");
+
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "sc.exe",
+                Arguments = arguments,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            using var process = Process.Start(psi);
+            if (process == null)
+                return LogResult(new ServiceCommandResult(arguments, null, false, string.Empty, "Process.Start returned null."), successExitCodes);
+
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+            if (!process.WaitForExit(TimeoutMs))
+            {
+                TryKill(process);
+                return LogResult(new ServiceCommandResult(arguments, null, true, string.Empty, $"Timed out after {TimeoutMs}ms."), successExitCodes);
+            }
+
+            var result = new ServiceCommandResult(
+                arguments,
+                process.ExitCode,
+                false,
+                stdoutTask.GetAwaiter().GetResult().Trim(),
+                stderrTask.GetAwaiter().GetResult().Trim());
+            return LogResult(result, successExitCodes);
+        }
+        catch (Exception ex)
+        {
+            return LogResult(new ServiceCommandResult(arguments, null, false, string.Empty, ex.Message), successExitCodes);
+        }
+    }
+
+    private static ServiceCommandResult LogResult(ServiceCommandResult result, int[] successExitCodes)
+    {
+        var ok = result.IsSuccess(successExitCodes);
+        var level = ok ? LogLevel.Info : LogLevel.Error;
+        Logger.Log($"[ServiceInstaller] sc.exe {result.Arguments} exit={result.ExitCode?.ToString() ?? "none"} timeout={result.TimedOut}", level);
+        if (!string.IsNullOrWhiteSpace(result.Output))
+            Logger.Log($"[ServiceInstaller] stdout: {result.Output}", LogLevel.Info);
+        if (!string.IsNullOrWhiteSpace(result.Error))
+            Logger.Log($"[ServiceInstaller] stderr: {result.Error}", ok ? LogLevel.Warn : LogLevel.Error);
+        return result;
+    }
+
+    private static void TryKill(Process process)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch
+        {
+        }
+    }
+}
+
+internal sealed record ServiceCommandResult(string Arguments, int? ExitCode, bool TimedOut, string Output, string Error)
+{
+    public bool IsSuccess(params int[] successExitCodes)
+        => !TimedOut && ExitCode.HasValue && successExitCodes.Contains(ExitCode.Value);
+}


### PR DESCRIPTION
## 背景

我本地拿 v2.7.5 portable 跑了一遍，没有完整复现 #40，尤其没复现出“删掉 CoreExtensions 后 service 就能起来”这个现象。

不过跑的时候看到 service 自动安装这块日志太少：App ping service 超时后会进 `SilentInstall()`，日志里基本只有“开始安装”和“完成”。如果 service 实际没注册成功，看不到 installer exit code，也看不到 `sc.exe` 的输出。

所以我先补这块日志。不一定能够修复 #40，但之后再遇到类似问题，至少日志里能看出是权限、runtime、`sc.exe`，还是别的环节失败。

CoreExtensions 我也试着移走过，在我这边不会让 service 安装成功，只是主题资源没了，所以这个 PR 先不动它。

## 改动

- 给 App 侧的 elevated installer 等待加了超时和退出码日志。
- `SilentInstall()` 完成后会检查 `SwiftListService` 是否真的注册到当前 service exe 路径。
- `TryStartWithoutElevation()` 现在会记录 `sc start` 的退出码和超时。
- Service 侧安装/卸载流程统一通过 `ServiceControlRunner` 调用 `sc.exe`，记录 exit code、stdout/stderr 和 timeout。
- 安装/卸载失败时设置非 0 exit code，避免 App 把失败的 installer 当成成功。

## 本地验证

- `dotnet format style .\Service\Service.csproj --severity warn`
- `dotnet format style .\App\App.csproj --severity warn`
- `dotnet build .\Service\Service.csproj /p:UseSharedCompilation=false`
- `dotnet build .\App\App.csproj /p:UseSharedCompilation=false`
- 普通权限运行 `SwiftList.Service.exe --install`：
  - 没有创建 `SwiftListService`
  - 退出码为 `1`
  - `service.log` 记录了 `sc create ... exit=5`

这个改动主要是避免日志里只剩一个没有实际意义的 “completed”。
